### PR TITLE
fix(projects): improve database filtering in project view

### DIFF
--- a/api/types/resources.types.ts
+++ b/api/types/resources.types.ts
@@ -1,5 +1,5 @@
 import { CoolifyApplications } from "./application.types";
-import { CoolifyDatabases } from "./database.types";
+import { CoolifyDatabases, CoolifyDatabaseType } from "./database.types";
 import { SingleServer } from "./server.types";
 import { CoolifyServices } from "./services.types";
 
@@ -41,8 +41,8 @@ export type ResourceBase = {
 };
 
 export type ResourceFromListType =
+  | CoolifyDatabaseType
   | "application"
-  | "standalone-postgresql"
   | "service";
 
 export type Resource = ResourceBase & {

--- a/app/main/projects/[uuid].tsx
+++ b/app/main/projects/[uuid].tsx
@@ -1,6 +1,7 @@
 import { getProject } from "@/api/projects";
 import { getResources } from "@/api/resources";
-import { ResourceType } from "@/api/types/resources.types";
+import { CoolifyDatabaseType } from "@/api/types/database.types";
+import { Resource, ResourceType } from "@/api/types/resources.types";
 import { ResourceCard } from "@/components/cards/ResourceCard";
 import { ChevronUp } from "@/components/icons/ChevronUp";
 import { SafeView } from "@/components/SafeView";
@@ -12,6 +13,12 @@ import { useQuery } from "@tanstack/react-query";
 import { LinkProps, useLocalSearchParams, useNavigation } from "expo-router";
 import { useEffect, useState } from "react";
 import { RefreshControl, SectionList, View } from "react-native";
+
+const isDatabase = (resource: Resource) => {
+  return Object.values(CoolifyDatabaseType).includes(
+    resource.type as CoolifyDatabaseType
+  );
+};
 
 export default function Project() {
   const navigation = useNavigation();
@@ -69,9 +76,7 @@ export default function Project() {
   const applications = filteredResources.filter(
     (res) => res.type === "application"
   );
-  const databases = filteredResources.filter((res) =>
-    res.name.includes("database")
-  );
+  const databases = filteredResources.filter(isDatabase);
   const services = filteredResources.filter((res) => res.type === "service");
 
   const sections = [


### PR DESCRIPTION
## Summary

Updates the database filtering logic in the project view to properly filter databases by their type instead of relying on name matching. This change ensures more accurate and reliable database resource filtering.

## Changes

- Import CoolifyDatabaseType from database types
- Add isDatabase helper function to check resource type against database types
- Update ResourceFromListType to use CoolifyDatabaseType instead of hardcoded standalone-postgresql
- Replace name-based database filtering with type-based filtering using isDatabase function

## Additional Notes

- This change makes database filtering more robust by using the actual database types rather than relying on name pattern matching
- The fix ensures all database types are properly categorized in the project view
- No UI changes are required as this is purely a logic improvement