### PR TITLE
Add Server unreachable handling and setup redirect

### DIFF
--- a/api/client.ts
+++ b/api/client.ts
@@ -36,8 +36,8 @@ export async function coolifyFetch<T>(
   }
 
   try {
+    console.log(`[${method}] ${endpoint}`);
     const response = await fetch(url, fetchOptions);
-    console.log(`[${method}] [${response.status}] ${endpoint}`);
 
     if (response.status >= 400) {
       const error = await response.json();

--- a/api/client.ts
+++ b/api/client.ts
@@ -9,7 +9,7 @@ export async function coolifyFetch<T>(
     method?: string;
     body?: any;
     headers?: Record<string, string>;
-  } = {}
+  } = {},
 ): Promise<T> {
   const { method = "GET", body, headers = {}, isText = false } = options;
   const serverAddress = await SecureStore.getItemAsync(Secrets.SERVER_ADDRESS);
@@ -56,7 +56,7 @@ export async function coolifyFetch<T>(
 }
 
 export async function optimisticUpdateInsertOneToMany<
-  T extends { uuid?: string; deployment_uuid?: string }
+  T extends { uuid?: string; deployment_uuid?: string },
 >(queryKey: (string | number)[], data: T) {
   await queryClient.cancelQueries({ queryKey });
 
@@ -74,7 +74,7 @@ export async function optimisticUpdateInsertOneToMany<
       (resource) =>
         (identifierKey === "deployment_uuid" &&
           resource.deployment_uuid === identifierValue) ||
-        (identifierKey === "uuid" && resource.uuid === identifierValue)
+        (identifierKey === "uuid" && resource.uuid === identifierValue),
     );
 
     if (index === -1) return [...old, data];
@@ -84,7 +84,7 @@ export async function optimisticUpdateInsertOneToMany<
         resource.deployment_uuid === identifierValue) ||
       (identifierKey === "uuid" && resource.uuid === identifierValue)
         ? { ...resource, ...data }
-        : resource
+        : resource,
     );
   });
 
@@ -93,7 +93,7 @@ export async function optimisticUpdateInsertOneToMany<
 
 export async function optimisticUpdateOne<T>(
   queryKey: (string | number)[],
-  data: T
+  data: T,
 ) {
   await queryClient.cancelQueries({ queryKey });
 
@@ -116,7 +116,7 @@ export const onOptimisticUpdateError = (
     previousData: unknown;
     queryKeyAll?: (string | number)[];
     previousDataAll?: unknown;
-  }
+  },
 ) => {
   if (!context) return;
   queryClient.setQueryData(context.queryKey, context.previousData);
@@ -132,7 +132,7 @@ export const onOptimisticUpdateSettled = (customKey?: (string | number)[]) => {
     data?: unknown,
     error?: unknown,
     variables?: unknown,
-    context?: { queryKey: (string | number)[] }
+    context?: { queryKey: (string | number)[] },
   ) => {
     queryClient.invalidateQueries({
       queryKey: customKey ?? context?.queryKey,

--- a/api/status.ts
+++ b/api/status.ts
@@ -6,6 +6,10 @@ type VersionResponse = {
 };
 
 export async function getHealth(address: string): Promise<string> {
+  if (!address) throw new Error("Server address is required");
+
+  console.log(`[GET] /api/v1/health`);
+
   const normalizedAddress = address.replace(/\/+$/, "");
   return fetch(`${normalizedAddress}/api/v1/health`).then((res) => res.text());
 }

--- a/app/error/_layout.tsx
+++ b/app/error/_layout.tsx
@@ -1,7 +1,11 @@
 import { SplashScreen, Stack } from "expo-router";
+import { useEffect } from "react";
 
 export default function ErrorLayout() {
-  SplashScreen.hide();
+  useEffect(() => {
+    SplashScreen.hide();
+  }, []);
+
   return (
     <Stack
       screenOptions={{

--- a/app/error/_layout.tsx
+++ b/app/error/_layout.tsx
@@ -1,0 +1,18 @@
+import { SplashScreen, Stack } from "expo-router";
+
+export default function ErrorLayout() {
+  SplashScreen.hide();
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        presentation: "fullScreenModal",
+      }}
+    >
+      <Stack.Screen
+        name="server_unreachable"
+        options={{ title: "Server Unreachable" }}
+      />
+    </Stack>
+  );
+}

--- a/app/error/server_unreachable.tsx
+++ b/app/error/server_unreachable.tsx
@@ -1,0 +1,61 @@
+import { Button } from "@/components/ui/button";
+import { Text } from "@/components/ui/text";
+import { H1 } from "@/components/ui/typography";
+import useServerStatus from "@/hooks/useServerStatus";
+import { useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "expo-router";
+import { useCallback, useEffect, useState } from "react";
+import { View } from "react-native";
+import { toast } from "sonner-native";
+
+export default function ServerUnreachable() {
+  const router = useRouter();
+  const { refetch } = useServerStatus();
+  const queryClient = useQueryClient();
+  const [retrying, setRetrying] = useState(false);
+
+  useEffect(() => {
+    queryClient.cancelQueries();
+  }, []);
+
+  const handleRetry = useCallback(async () => {
+    setRetrying(true);
+    try {
+      const result = await refetch();
+      if (!result.data) {
+        toast.error(
+          "Server still unreachable. Please check your connection or configuration.",
+        );
+      } else {
+        router.replace("/");
+      }
+    } finally {
+      setRetrying(false);
+    }
+  }, [refetch, router]);
+
+  return (
+    <View className="flex-1 items-center justify-center gap-4 p-6">
+      <H1 className="text-center text-lg">Server Unreachable</H1>
+      <Text className="text-center text-muted-foreground">
+        The server could not be reached. Check your connection and try again.
+      </Text>
+      <View className="flex-row gap-2">
+        <Button
+          onPress={handleRetry}
+          loading={retrying}
+          className="min-w-[120]"
+        >
+          <Text>Retry</Text>
+        </Button>
+        <Button
+          variant="secondary"
+          onPress={() => router.push("/setup/serverAddress")}
+          disabled={retrying}
+        >
+          <Text>Reconfigure</Text>
+        </Button>
+      </View>
+    </View>
+  );
+}

--- a/app/error/server_unreachable.tsx
+++ b/app/error/server_unreachable.tsx
@@ -2,32 +2,27 @@ import { Button } from "@/components/ui/button";
 import { Text } from "@/components/ui/text";
 import { H1 } from "@/components/ui/typography";
 import useServerStatus from "@/hooks/useServerStatus";
-import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { View } from "react-native";
 import { toast } from "sonner-native";
 
 export default function ServerUnreachable() {
   const router = useRouter();
   const { refetch } = useServerStatus();
-  const queryClient = useQueryClient();
   const [retrying, setRetrying] = useState(false);
-
-  useEffect(() => {
-    queryClient.cancelQueries();
-  }, []);
 
   const handleRetry = useCallback(async () => {
     setRetrying(true);
     try {
       const result = await refetch();
-      if (!result.data) {
+
+      if (result.data !== "OK") {
         toast.error(
           "Server still unreachable. Please check your connection or configuration.",
         );
       } else {
-        router.replace("/");
+        router.replace("/main");
       }
     } finally {
       setRetrying(false);
@@ -50,7 +45,15 @@ export default function ServerUnreachable() {
         </Button>
         <Button
           variant="secondary"
-          onPress={() => router.push("/setup/serverAddress")}
+          onPress={() =>
+            router.push({
+              pathname: "/setup/serverAddress",
+              params: {
+                reconfigure: "true",
+                redirect: "/main",
+              },
+            })
+          }
           disabled={retrying}
         >
           <Text>Reconfigure</Text>

--- a/app/main/_layout.tsx
+++ b/app/main/_layout.tsx
@@ -3,15 +3,17 @@ import { SettingsIcon } from "@/components/icons/Settings";
 import { APP_NAME } from "@/constants/AppDetails";
 import useServerStatus from "@/hooks/useServerStatus";
 import { router, Stack } from "expo-router";
+import { useEffect } from "react";
 import { TouchableOpacity } from "react-native";
 
 export default function MainLayout() {
   const { healthy } = useServerStatus();
 
-  if (healthy === false) {
-    router.navigate("/error/server_unreachable");
-    return null;
-  }
+  useEffect(() => {
+    if (healthy === false) {
+      router.navigate("/error/server_unreachable");
+    }
+  }, [healthy]);
 
   return (
     <Stack

--- a/app/main/_layout.tsx
+++ b/app/main/_layout.tsx
@@ -1,10 +1,18 @@
 import { AddResourceButton } from "@/components/AddResourceButton";
 import { SettingsIcon } from "@/components/icons/Settings";
 import { APP_NAME } from "@/constants/AppDetails";
+import useServerStatus from "@/hooks/useServerStatus";
 import { router, Stack } from "expo-router";
 import { TouchableOpacity } from "react-native";
 
 export default function MainLayout() {
+  const { healthy } = useServerStatus();
+
+  if (healthy === false) {
+    router.navigate("/error/server_unreachable");
+    return null;
+  }
+
   return (
     <Stack
       screenOptions={{

--- a/app/setup/api_token.tsx
+++ b/app/setup/api_token.tsx
@@ -5,13 +5,16 @@ import { PasswordInput } from "@/components/ui/input";
 import { Text } from "@/components/ui/text";
 import { APP_NAME } from "@/constants/AppDetails";
 import useSetup from "@/hooks/useSetup";
-import { router, useLocalSearchParams } from "expo-router";
+import { RelativePathString, router, useLocalSearchParams } from "expo-router";
 import { openBrowserAsync } from "expo-web-browser";
 import React, { useState } from "react";
 import { Alert as NativeAlert, View } from "react-native";
 
 export default function ApiTokenStep() {
-  const { reconfigure } = useLocalSearchParams<{ reconfigure: string }>();
+  const { reconfigure, redirect } = useLocalSearchParams<{
+    reconfigure: string;
+    redirect: RelativePathString;
+  }>();
   const { setApiToken, serverAddress, setupComplete } = useSetup();
 
   const [token, setToken] = useState("");
@@ -21,7 +24,7 @@ export default function ApiTokenStep() {
 
   const navigate = () => {
     if (reconfigure) {
-      router.dismissTo("/main/settings");
+      router.dismissTo(redirect ?? "/main/settings");
     } else {
       router.navigate("/setup/permissions");
     }

--- a/app/setup/api_token.tsx
+++ b/app/setup/api_token.tsx
@@ -12,25 +12,27 @@ import { Alert as NativeAlert, View } from "react-native";
 
 export default function ApiTokenStep() {
   const { reconfigure } = useLocalSearchParams<{ reconfigure: string }>();
-  const { setApiToken, serverAddress } = useSetup();
+  const { setApiToken, serverAddress, setupComplete } = useSetup();
 
   const [token, setToken] = useState("");
   const [valid, setValid] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | undefined>();
 
+  const navigate = () => {
+    if (reconfigure) {
+      router.dismissTo("/main/settings");
+    } else {
+      router.navigate("/setup/permissions");
+    }
+  };
+
   const saveKey = () => {
     if (valid) {
       setLoading(true);
       setApiToken(token)
         .then(() => setError(undefined))
-        .then(() => {
-          if (reconfigure) {
-            router.dismissTo("/main/settings");
-          } else {
-            router.navigate("/setup/permissions");
-          }
-        })
+        .then(() => navigate())
         .catch((e) => setError(e.message))
         .finally(() => setLoading(false));
     } else {
@@ -103,6 +105,11 @@ export default function ApiTokenStep() {
       >
         <Text className="text-black">Save</Text>
       </Button>
+      {setupComplete && (
+        <Button onPress={navigate} variant="ghost">
+          <Text>Skip</Text>
+        </Button>
+      )}
       {!!error && <Text className="text-red-400">{error}</Text>}
     </SetupScreenContainer>
   );

--- a/app/setup/api_token.tsx
+++ b/app/setup/api_token.tsx
@@ -25,6 +25,8 @@ export default function ApiTokenStep() {
   const navigate = () => {
     if (reconfigure) {
       router.dismissTo(redirect ?? "/main/settings");
+    } else if (setupComplete) {
+      router.navigate(redirect ?? "/main");
     } else {
       router.navigate("/setup/permissions");
     }

--- a/app/setup/serverAddress.tsx
+++ b/app/setup/serverAddress.tsx
@@ -3,12 +3,15 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Text } from "@/components/ui/text";
 import useSetup from "@/hooks/useSetup";
-import { router, useLocalSearchParams } from "expo-router";
+import { RelativePathString, router, useLocalSearchParams } from "expo-router";
 import React, { useEffect, useState } from "react";
 import { Alert } from "react-native";
 
 export default function ServerStep() {
-  const { reconfigure } = useLocalSearchParams<{ reconfigure: string }>();
+  const { reconfigure, redirect } = useLocalSearchParams<{
+    reconfigure: string;
+    redirect: RelativePathString;
+  }>();
   const { setServerAddress, serverAddress } = useSetup();
 
   const [server, setServer] = useState("");
@@ -24,7 +27,7 @@ export default function ServerStep() {
         .then(() =>
           router.navigate({
             pathname: "/setup/api_token",
-            params: { reconfigure },
+            params: { reconfigure, redirect },
           }),
         )
         .catch((error: Error) => setError(error.message))

--- a/hooks/useServerStatus.ts
+++ b/hooks/useServerStatus.ts
@@ -1,0 +1,38 @@
+import { getHealth } from "@/api/status";
+import { useQuery } from "@tanstack/react-query";
+import useSetup from "./useSetup";
+
+export default function useServerStatus() {
+  const { serverAddress } = useSetup();
+
+  const {
+    data: health,
+    isLoading,
+    isError,
+    refetch,
+  } = useQuery({
+    queryKey: ["server-status", serverAddress ?? ""],
+    queryFn: () => getHealth(serverAddress ?? ""),
+    enabled: !!serverAddress,
+    retry: false,
+    refetchInterval: 60 * 1000,
+    refetchOnReconnect: true,
+    refetchOnMount: true,
+    refetchOnWindowFocus: true,
+    refetchIntervalInBackground: true,
+  });
+
+  if (!serverAddress) {
+    return { healthy: null, refetch };
+  }
+
+  if (isLoading) {
+    return { healthy: null, refetch };
+  }
+
+  if (isError || health !== "OK") {
+    return { healthy: false, refetch };
+  }
+
+  return { healthy: true, refetch };
+}

--- a/hooks/useSetup.ts
+++ b/hooks/useSetup.ts
@@ -33,20 +33,21 @@ export default function useSetup() {
       throw new Error("INVALID_URL");
     }
 
-    const health = await getHealth(address);
+    const normalizedAddress = address.replace(/\/api$|\/$/, "");
+
+    const health = await getHealth(normalizedAddress);
 
     if (health !== "OK") throw new Error("INVALID_SERVER");
-    queryClient.setQueryData(["server-status", address], health);
 
-    address = address.replace(/\/api$|\/$/, "");
-
-    if (address !== serverAddress) {
+    if (normalizedAddress !== serverAddress) {
       queryClient.invalidateQueries();
       queryClient.clear();
     }
 
-    await SecureStore.setItemAsync(Secrets.SERVER_ADDRESS, address);
-    setServerAddressState(address);
+    queryClient.setQueryData(["server-status", normalizedAddress], health);
+
+    await SecureStore.setItemAsync(Secrets.SERVER_ADDRESS, normalizedAddress);
+    setServerAddressState(normalizedAddress);
   };
 
   const setPermissions = async (saved: boolean) => {


### PR DESCRIPTION
## Summary
- Show a dedicated error screen when the server is unreachable and allow retry or reconfigure.
- Pass a configurable `redirect` through the reconfigure flow (server address → API token) so users return to the right place (e.g. `/main` after fixing the server).
- Keep server health in sync when the address changes (invalidate/clear queries, set server-status cache on successful health in setup).

## Changes
- **Error flow:** New `app/error/` route with `server_unreachable` screen (Retry + Reconfigure). Main layout redirects to it when `useServerStatus` reports unhealthy.
- **Setup:** `serverAddress` and `api_token` accept `redirect` param; reconfigure uses it (e.g. `redirect: "/main"`). API token step shows "Skip" when setup is already complete.
- **Health:** `useServerStatus` hook (React Query) for server health with refetch; `getHealth` validates non-empty address. `useSetup.setServerAddress` invalidates/clears queries and updates server-status cache when address is saved.
- **API client:** Request logging tweak (log before request, not after); minor formatting/typing fixes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new routing based on health polling and changes query-cache invalidation/clearing when the server address changes, which could affect navigation loops or stale-data behavior. Changes are contained to client-side UX and React Query state management (no auth/permissions logic changes).
> 
> **Overview**
> Adds a dedicated *server unreachable* UX: a new `/error/server_unreachable` route with Retry/Reconfigure actions, and `app/main/_layout.tsx` now navigates there when periodic health checks report the server as unhealthy.
> 
> Introduces `useServerStatus` (React Query) to poll `/api/v1/health` and expose `healthy`/`refetch`, tightens `getHealth` to reject empty addresses, and updates `useSetup.setServerAddress` to normalize addresses, clear/invalidate cached queries when the server changes, and pre-seed the `server-status` cache.
> 
> Improves setup navigation by threading an optional `redirect` param through server address → API token screens, adjusting reconfigure behavior to return to the requested route, and adding a Skip option on the token step when setup is already complete; also tweaks API request logging/formatting in `coolifyFetch`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69cbfc6282c2d657047f734ee0f095f0b873230d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->